### PR TITLE
MOVE SJ WORKER FUNCTIONALITY TO THE ENGINE

### DIFF
--- a/_posts/2014-05-01-supplejack-api.md
+++ b/_posts/2014-05-01-supplejack-api.md
@@ -65,3 +65,7 @@ Create a user.
 ### Cron Jobs
 
 Supplejack has a few cronjobs that will help with indexing records. You can see examples of them in `schedule.example.rb`. The main one you should add is the `SupplejackApi::IndexRemainingRecordsInQueue` as it will index records that are in the Redis queue when there is not yet enough of them to trigger an index automatically.
+
+## Supplejack Sidekiq
+
+Supplejack has it's own instance of Sidekiq that you will need to run for the Full and Flush harvest to work. Start Sidekiq from the api directory with `bundle exec sidekiq`. If you are running both Sidekiq instances on the same machine, you will need to point them at separate Redis databases otherwise you will end up in problems where the two Sidekiqs are trying to process each others jobs. This can be done by appending `/<number>` to the end of your Redis URL.

--- a/_posts/2014-05-01-supplejack-api.md
+++ b/_posts/2014-05-01-supplejack-api.md
@@ -61,3 +61,7 @@ Create a user.
  > SupplejackApi::User.last.authentication_token
 => "RhymLHa9xRQGU8gyAYXP"
 ```
+
+### Cron Jobs
+
+Supplejack has a few cronjobs that will help with indexing records. You can see examples of them in `schedule.example.rb`. The main one you should add is the `SupplejackApi::IndexRemainingRecordsInQueue` as it will index records that are in the Redis queue when there is not yet enough of them to trigger an index automatically.


### PR DESCRIPTION
**Acceptance Criteria**

IndexSourceWorker and FlushOldRecordsWorker are moved in to the SJ engine
ClearIndexBuffer, IndexBuffer, IndexWorker classes are moved in to the SJ engine
Namespaces are changed to be something more useful, eg
SupplejackApi::ClearIndexBuffer etc. to SupplejackApi::SolrActions::ClearIndexBuffer
Classes are renamed to something more useful, eg
IndexBuffer is really RedisRecordsBuffer
ClearIndexBuffer, is really IndexToSolr (devs to agree)
Open source SJ can do the things its meant to do out of the box (eg F&F harvest)
Update SJ documentation repo and release documentation
Update API scheduler with any new namespaces
Notes

Main driver to do this work is that some core SJ functionality (F&F) will not work with just the open source code.
Previous investigation https://basecamp.com/1723294/projects/8491945/messages/78025401
(this story covers both recommended stories in the above write up)