### PR TITLE
FACET METHOD: As an Open Source user, I want to be able to specify the facet methods used per facet field, so that my facet queries are as performant as possible. 

### DIFF
--- a/_drafts/schema-dsl-namespaces.md
+++ b/_drafts/schema-dsl-namespaces.md
@@ -20,6 +20,7 @@ where:
     * `solr_name` is a string which is the name of the field in Solr. Default: field's `name`.
     * `namespace` the namespace of this field.
     * `namespace_field` the field name from the namespace. Use if your field name is not the same as the defined in the namespace
+    * `facet_method` allows overriding the default facet method used by Solr. Valid values are 'enum', 'fc', or 'fcs'. More information about Solrs faceting methods can be found in the Solr documentation. 
 * `block`
     * `search_value` is a Ruby `Proc` which produces the value which should be indexed by Solr. The block is executed when the field is indexed. Must be the same type as the field's `type`. Default: `nil`.
 


### PR DESCRIPTION
**Acceptance Criteria**
- Facet method is able to be configured per facet field in an application that uses the Supplejack Engine. 
- Queries built by the API contain the appropriate facet method per facet field.
- Update open source documentation. 

**Notes**
- Initial idea here is that an open source user can add the facet method to the record schema in their application and then when the queries are being built the facet method is appended appropriately.
- Sunspot does not appear to support facet method, so we will need to add it through the `adjust_solr_params` block to get it to work. 

**Tests**
- When using debug=true on the API, we will be able to see the correct facet methods being used per facet. 